### PR TITLE
Avoid resampling when not necessary.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,9 +151,14 @@ fn read(
     };
     let (data, sample_rate) = match sample_rate {
         Some(out_sr) => {
-            let in_sr = reader.sample_rate() as usize;
-            let data = audio::resample2(&data, in_sr, out_sr as usize).w_f(&filename)?;
-            (data, out_sr)
+            let in_sr = reader.sample_rate();
+            if in_sr != out_sr {
+                let data =
+                    audio::resample2(&data, in_sr as usize, out_sr as usize).w_f(&filename)?;
+                (data, out_sr)
+            } else {
+                (data, in_sr)
+            }
         }
         None => {
             let sample_rate = reader.sample_rate();


### PR DESCRIPTION
The `audio::resample2` also avoids resampling when possible but ends up copying the data when the input and output sample rates are the same. Here we just bypass the resampling where possible.